### PR TITLE
Fix list route duplication and restore get/list handlers

### DIFF
--- a/get/function.json
+++ b/get/function.json
@@ -6,7 +6,7 @@
       "direction": "in",
       "name": "req",
       "methods": ["get", "options"],
-      "route": "list"
+      "route": "get"
     },
     { "type": "http", "direction": "out", "name": "res" }
   ]

--- a/get/index.js
+++ b/get/index.js
@@ -1,8 +1,12 @@
+// CommonJS. Node 20 on Azure Functions.
 const { DefaultAzureCredential } = require("@azure/identity");
 const { BlobServiceClient } = require("@azure/storage-blob");
 
-const ALLOWED_ORIGIN = process.env.ALLOWED_ORIGIN || "https://mystro-sec-endpoint-bjecbgefdbgmhbdv.australiaeast-01.azurewebsites.net";
+const ALLOWED_ORIGIN =
+  process.env.ALLOWED_ORIGIN ||
+  "https://mystro-sec-endpoint-bjecbgefdbgmhbdv.australiaeast-01.azurewebsites.net";
 
+// CORS helper
 function corsHeaders(extra = {}) {
   return {
     "Access-Control-Allow-Origin": ALLOWED_ORIGIN,
@@ -10,14 +14,14 @@ function corsHeaders(extra = {}) {
     "Access-Control-Allow-Methods": "GET,OPTIONS",
     "Access-Control-Allow-Headers": "Content-Type, Authorization",
     "Access-Control-Max-Age": "86400",
-    ...extra
+    ...extra,
   };
 }
 
 module.exports = async function (context, req) {
   const log = context.log;
 
-  // Preflight
+  // Preflight check
   if ((req.method || "").toUpperCase() === "OPTIONS") {
     context.res = { status: 204, headers: corsHeaders() };
     return;
@@ -25,35 +29,95 @@ module.exports = async function (context, req) {
 
   try {
     const account = process.env.STORAGE_ACCOUNT_NAME;
-    const containerName = (req.query.container || process.env.CONTAINER_NAME || "json-outbound").toString();
+    const containerName = (
+      req.query.container ||
+      process.env.CONTAINER_NAME ||
+      "json-outbound"
+    ).toString();
+    const name = (req.query.name || "").toString();
 
-    log("LIST DEBUG: account, container:", account, containerName);
+    log("GET DEBUG: Incoming request", { account, containerName, name });
+
     if (!account) {
-      context.res = { status: 500, headers: corsHeaders({ "Content-Type": "application/json" }), body: { error: "Missing STORAGE_ACCOUNT_NAME" } };
+      context.res = {
+        status: 500,
+        headers: corsHeaders({ "Content-Type": "application/json" }),
+        body: { error: "Missing STORAGE_ACCOUNT_NAME" },
+      };
       return;
     }
 
-    const credential = new DefaultAzureCredential();
-    const service = new BlobServiceClient(`https://${account}.blob.core.windows.net`, credential);
+    if (!name) {
+      context.res = {
+        status: 400,
+        headers: corsHeaders({ "Content-Type": "application/json" }),
+        body: { error: "Missing query parameter 'name'" },
+      };
+      return;
+    }
+
+    const cred = new DefaultAzureCredential();
+    const service = new BlobServiceClient(
+      `https://${account}.blob.core.windows.net`,
+      cred
+    );
     const container = service.getContainerClient(containerName);
 
-    const exists = await container.exists();
-    log("LIST DEBUG: container exists?", exists);
-    if (!exists) {
-      context.res = { status: 404, headers: corsHeaders({ "Content-Type": "application/json" }), body: { error: "Container not found", account, container: containerName } };
+    if (!(await container.exists())) {
+      context.res = {
+        status: 404,
+        headers: corsHeaders({ "Content-Type": "application/json" }),
+        body: { error: "Container not found", account, container: containerName },
+      };
       return;
     }
 
-    const names = [];
-    for await (const b of container.listBlobsFlat()) names.push(b.name);
+    const blob = container.getBlobClient(name);
+    if (!(await blob.exists())) {
+      context.res = {
+        status: 404,
+        headers: corsHeaders({ "Content-Type": "application/json" }),
+        body: { error: "Blob not found", name },
+      };
+      return;
+    }
+
+    const props = await blob.getProperties();
+    const dl = await blob.download();
+    const text = await streamToString(dl.readableStreamBody);
+
+    let parsed;
+    try {
+      parsed = JSON.parse(text);
+    } catch (err) {
+      parsed = { raw: text };
+    }
 
     context.res = {
       status: 200,
       headers: corsHeaders({ "Content-Type": "application/json" }),
-      body: names
+      body: {
+        lastModified: props.lastModified,
+        name,
+        data: parsed,
+      },
     };
   } catch (err) {
-    log.error("LIST ERROR:", err);
-    context.res = { status: 500, headers: corsHeaders({ "Content-Type": "application/json" }), body: { error: "List failed", detail: String(err) } };
+    log.error("GET ERROR:", err);
+    context.res = {
+      status: 500,
+      headers: corsHeaders({ "Content-Type": "application/json" }),
+      body: { error: "Get failed", detail: String(err) },
+    };
   }
 };
+
+// Helper to consume a stream into a string
+function streamToString(stream) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    stream.on("data", (d) => chunks.push(Buffer.from(d)));
+    stream.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    stream.on("error", reject);
+  });
+}

--- a/list/index.js
+++ b/list/index.js
@@ -1,7 +1,70 @@
-module.exports = async (context, req) => {
-  context.res = {
-    status: 200,
-    headers: { "Content-Type": "application/json" },
-    body: ["ok"]
+// CommonJS. Node 20 on Azure Functions.
+const { DefaultAzureCredential } = require("@azure/identity");
+const { BlobServiceClient } = require("@azure/storage-blob");
+
+const MAX_RESULTS = 50;
+
+// CORS
+const ALLOWED_ORIGIN = process.env.ALLOWED_ORIGIN ||
+  "https://mystro-sec-endpoint-bjecbgefdbgmhbdv.australiaeast-01.azurewebsites.net";
+function corsHeaders(extra = {}) {
+  return {
+    "Access-Control-Allow-Origin": ALLOWED_ORIGIN,
+    "Vary": "Origin",
+    "Access-Control-Allow-Methods": "GET,OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type, Authorization",
+    "Access-Control-Max-Age": "86400",
+    ...extra
   };
+}
+
+module.exports = async function (context, req) {
+  // Preflight
+  if ((req.method || "").toUpperCase() === "OPTIONS") {
+    context.res = { status: 204, headers: corsHeaders() };
+    return;
+  }
+
+  try {
+    const account = process.env.STORAGE_ACCOUNT_NAME;
+    const containerName = (req.query.container || process.env.CONTAINER_NAME || "json-outbound").toString();
+
+    if (!account) {
+      context.res = { status: 500, headers: corsHeaders({ "Content-Type": "application/json" }), body: { error: "Missing STORAGE_ACCOUNT_NAME" } };
+      return;
+    }
+
+    const cred = new DefaultAzureCredential();
+    const service = new BlobServiceClient(`https://${account}.blob.core.windows.net`, cred);
+    const container = service.getContainerClient(containerName);
+
+    if (!(await container.exists())) {
+      context.res = {
+        status: 404,
+        headers: corsHeaders({ "Content-Type": "application/json" }),
+        body: { error: "Container not found", account, container: containerName }
+      };
+      return;
+    }
+
+    const items = [];
+    for await (const blob of container.listBlobsFlat()) {
+      const name = blob.name || "";
+      if (!name.endsWith(".json") || !name.includes("assessment_")) continue;
+      items.push({ name, lastModified: blob.properties.lastModified });
+      if (items.length >= MAX_RESULTS) break;
+    }
+
+    // newest-first by name (your naming already sorts lexicographically)
+    items.sort((a, b) => (b.name || "").localeCompare(a.name || ""));
+
+    context.res = { status: 200, headers: corsHeaders({ "Content-Type": "application/json" }), body: { items } };
+  } catch (err) {
+    context.log.error("List failed:", err);
+    context.res = {
+      status: 500,
+      headers: corsHeaders({ "Content-Type": "application/json" }),
+      body: { error: "List failed", detail: String(err) }
+    };
+  }
 };


### PR DESCRIPTION
## Summary
- Assign `/list` route to the proper listing function
- Restore blob retrieval logic for `/get`
- Ensure each HTTP function has a unique route

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689dc48d8d4c8323917d7c0e26d07ecf